### PR TITLE
Closes #21 - Workflow using bad loop

### DIFF
--- a/hello/hello_signal.py
+++ b/hello/hello_signal.py
@@ -16,7 +16,7 @@ class GreetingWorkflow:
     async def run(self) -> List[str]:
         # Continually handle from queue or wait for exit to be received
         greetings: List[str] = []
-        while not self._exit:
+        while True:
             # Wait for queue item or exit
             await workflow.wait_condition(
                 lambda: not self._pending_greetings.empty() or self._exit
@@ -26,7 +26,9 @@ class GreetingWorkflow:
             while not self._pending_greetings.empty():
                 greetings.append(f"Hello, {self._pending_greetings.get_nowait()}")
 
-        return greetings
+            # Exit it complete
+            if self._exit:
+                return greetings
 
     @workflow.signal
     async def submit_greeting(self, name: str) -> None:

--- a/hello/hello_signal.py
+++ b/hello/hello_signal.py
@@ -26,7 +26,7 @@ class GreetingWorkflow:
             while not self._pending_greetings.empty():
                 greetings.append(f"Hello, {self._pending_greetings.get_nowait()}")
 
-            # Exit it complete
+            # Exit if complete
             if self._exit:
                 return greetings
 


### PR DESCRIPTION
## What was changed
Check for exit signal later in the loop so we avoid exiting the workflow before other signals are received

## Why?
Wanted to help since I'm studying temporal (and the python sdk) right now

## Checklist

1. Closes #21 

2. How was this tested:
There's no test for the workflow at the moment and I'm not sure how to reproduce what was stated in the issue but can make one if you give me some direction.

3. Any docs updates needed?
No