### PR TITLE
Update default encryption key

### DIFF
--- a/encryption/codec.py
+++ b/encryption/codec.py
@@ -6,7 +6,7 @@ from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from temporalio.api.common.v1 import Payload
 from temporalio.converter import PayloadCodec
 
-default_key = base64.b64decode(b"MkUb3RVdHQuOTedqETZW7ra2GkZqpBRmYWRACUospMc=")
+default_key = b"test-key-test-key-test-key-test!"
 default_key_id = "my-key"
 
 
@@ -43,7 +43,7 @@ class EncryptionCodec(PayloadCodec):
             # Confirm our key ID is the same
             key_id = p.metadata.get("encryption-key-id", b"").decode()
             if key_id != self.key_id:
-                raise ValueError(f"Unrecognized key ID {key_id}")
+                raise ValueError(f"Unrecognized key ID {key_id}. Current key ID is {self.key_id}.")
             # Decrypt and append
             ret.append(Payload.FromString(self.decrypt(p.data)))
         return ret

--- a/encryption/codec.py
+++ b/encryption/codec.py
@@ -7,7 +7,7 @@ from temporalio.api.common.v1 import Payload
 from temporalio.converter import PayloadCodec
 
 default_key = b"test-key-test-key-test-key-test!"
-default_key_id = "my-key"
+default_key_id = "test-key-id"
 
 
 class EncryptionCodec(PayloadCodec):

--- a/encryption/codec.py
+++ b/encryption/codec.py
@@ -43,7 +43,9 @@ class EncryptionCodec(PayloadCodec):
             # Confirm our key ID is the same
             key_id = p.metadata.get("encryption-key-id", b"").decode()
             if key_id != self.key_id:
-                raise ValueError(f"Unrecognized key ID {key_id}. Current key ID is {self.key_id}.")
+                raise ValueError(
+                    f"Unrecognized key ID {key_id}. Current key ID is {self.key_id}."
+                )
             # Decrypt and append
             ret.append(Payload.FromString(self.decrypt(p.data)))
         return ret

--- a/encryption/starter.py
+++ b/encryption/starter.py
@@ -20,7 +20,7 @@ async def main():
 
     # Run workflow
     result = await client.execute_workflow(
-        @workflow.defn(name="Workflow"),
+        GreetingWorkflow.run,
         "Temporal",
         id=f"encryption-workflow-id",
         task_queue="encryption",

--- a/encryption/starter.py
+++ b/encryption/starter.py
@@ -20,10 +20,10 @@ async def main():
 
     # Run workflow
     result = await client.execute_workflow(
-        GreetingWorkflow.run,
+        @workflow.defn(name="Workflow"),
         "Temporal",
         id=f"encryption-workflow-id",
-        task_queue="encryption-task-queue",
+        task_queue="encryption",
     )
     print(f"Workflow result: {result}")
 

--- a/encryption/worker.py
+++ b/encryption/worker.py
@@ -9,7 +9,7 @@ from temporalio.worker import Worker
 from encryption.codec import EncryptionCodec
 
 
-@workflow.defn
+@workflow.defn(name="Workflow")
 class GreetingWorkflow:
     @workflow.run
     async def run(self, name: str) -> str:


### PR DESCRIPTION
Updating default key to match those used in Go and TS.

Using python encryption starter with Go worker works, with: 

- this PR
- this patch:

```
diff --git a/encryption/starter.py b/encryption/starter.py
index 4c39f55..4f26d71 100644
--- a/encryption/starter.py
+++ b/encryption/starter.py
@@ -20,10 +20,10 @@ async def main():
 
     # Run workflow
     result = await client.execute_workflow(
-        GreetingWorkflow.run,
+        "Workflow",
         "Temporal",
         id=f"encryption-workflow-id",
-        task_queue="encryption-task-queue",
+        task_queue="encryption",
     )
     print(f"Workflow result: {result}")
 ```
 
- and commenting out the key id check (Go code appears to use `"test"` for the default key id, but in history it's empty `"encryption-key-id": "",`)