### PR TITLE
Ensure a strong reference to asyncio Task for auto-heartbeater

### DIFF
--- a/custom_decorator/activity_utils.py
+++ b/custom_decorator/activity_utils.py
@@ -13,28 +13,27 @@ def auto_heartbeater(fn: F) -> F:
     # available via our wrapper, so we use the functools wraps decorator
     @wraps(fn)
     async def wrapper(*args, **kwargs):
-        done = asyncio.Event()
-        # Heartbeat twice as often as the timeout
         heartbeat_timeout = activity.info().heartbeat_timeout
+        heartbeat_task = None
         if heartbeat_timeout:
-            _ = asyncio.create_task(
-                heartbeat_every(heartbeat_timeout.total_seconds() / 2, done)
+            # Heartbeat twice as often as the timeout
+            heartbeat_task = asyncio.create_task(
+                heartbeat_every(heartbeat_timeout.total_seconds() / 2)
             )
         try:
             return await fn(*args, **kwargs)
         finally:
-            done.set()
+            if heartbeat_task:
+                heartbeat_task.cancel()
+                # Wait for heartbeat cancellation to complete
+                await asyncio.wait([heartbeat_task])
 
     return cast(F, wrapper)
 
 
-async def heartbeat_every(
-    delay: float, done_event: asyncio.Event, *details: Any
-) -> None:
+async def heartbeat_every(delay: float, *details: Any) -> None:
     # Heartbeat every so often while not cancelled
-    while not done_event.is_set():
-        try:
-            await asyncio.wait_for(done_event.wait(), delay)
-        except asyncio.TimeoutError:
-            print(f"Heartbeating at {datetime.now()}")
-            activity.heartbeat(*details)
+    while True:
+        await asyncio.sleep(delay)
+        print(f"Heartbeating at {datetime.now()}")
+        activity.heartbeat(*details)

--- a/custom_decorator/activity_utils.py
+++ b/custom_decorator/activity_utils.py
@@ -17,7 +17,7 @@ def auto_heartbeater(fn: F) -> F:
         # Heartbeat twice as often as the timeout
         heartbeat_timeout = activity.info().heartbeat_timeout
         if heartbeat_timeout:
-            asyncio.create_task(
+            _ = asyncio.create_task(
                 heartbeat_every(heartbeat_timeout.total_seconds() / 2, done)
             )
         try:

--- a/hello/hello_async_activity_completion.py
+++ b/hello/hello_async_activity_completion.py
@@ -22,7 +22,7 @@ class GreetingComposer:
         # Schedule a task to complete this asynchronously. This could be done in
         # a completely different process or system.
         print("Completing activity asynchronously")
-        asyncio.create_task(self.complete_greeting(activity.info().task_token, input))
+        _ = asyncio.create_task(self.complete_greeting(activity.info().task_token, input))
 
         # Raise the complete-async error which will complete this function but
         # does not consider the activity complete from the workflow perspective

--- a/hello/hello_async_activity_completion.py
+++ b/hello/hello_async_activity_completion.py
@@ -22,7 +22,9 @@ class GreetingComposer:
         # Schedule a task to complete this asynchronously. This could be done in
         # a completely different process or system.
         print("Completing activity asynchronously")
-        _ = asyncio.create_task(self.complete_greeting(activity.info().task_token, input))
+        _ = asyncio.create_task(
+            self.complete_greeting(activity.info().task_token, input)
+        )
 
         # Raise the complete-async error which will complete this function but
         # does not consider the activity complete from the workflow perspective

--- a/hello/hello_async_activity_completion.py
+++ b/hello/hello_async_activity_completion.py
@@ -22,6 +22,11 @@ class GreetingComposer:
         # Schedule a task to complete this asynchronously. This could be done in
         # a completely different process or system.
         print("Completing activity asynchronously")
+        # Tasks stored by asyncio are weak references and therefore can get GC'd
+        # which can cause warnings like "Task was destroyed but it is pending!".
+        # So we store the tasks ourselves.
+        # See https://docs.python.org/3/library/asyncio-task.html#creating-tasks,
+        # https://bugs.python.org/issue21163 and others.
         _ = asyncio.create_task(
             self.complete_greeting(activity.info().task_token, input)
         )


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Assigned the output of `asyncio.create_task()` to a temporary variable.

## Why?

I learned that one should store the return value of any call to `asyncio.create_task()` in order to maintain a strong reference to the Task.

Otherwise the Task can unexpectedly disappear mid-execution, as Python’s garbage collector will occasionally dispose of weak references.

From https://docs.python.org/3/library/asyncio-task.html#creating-tasks

> asyncio.**create_task**(coro, *, name=None, context=None)
> […]
> Important: Save a reference to the result of this function, to avoid a task disappearing mid-execution. The event loop only keeps weak references to tasks. A task that isn’t referenced elsewhere may get garbage collected at any time, even before it’s done.


## Checklist
<!--- add/delete as needed --->

**1. How was this tested:**
<!--- Please describe how you tested your changes/how we can test them -->

- [x] Tested the `custom_decorator/` scenario. ✅ 
```
cd ./custom_decorator
poetry run python worker.py &
poetry run python starter.py
```
- [x] Tested `poetry run python hello/hello_async_activity_completion.py` ✅ 



**2. Any docs updates needed?**
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

Nope, backwards-compatible change.