### PR TITLE
unrestrict sentry workflow interceptor sdk call

### DIFF
--- a/sentry/interceptor.py
+++ b/sentry/interceptor.py
@@ -5,7 +5,10 @@ from temporalio import activity, workflow
 from temporalio.worker import (
     ActivityInboundInterceptor,
     ExecuteActivityInput,
+    ExecuteWorkflowInput,
     Interceptor,
+    WorkflowInboundInterceptor,
+    WorkflowInterceptorClassInput,
 )
 
 with workflow.unsafe.imports_passed_through():
@@ -41,6 +44,29 @@ class _SentryActivityInboundInterceptor(ActivityInboundInterceptor):
                 raise e
 
 
+class _SentryWorkflowInterceptor(WorkflowInboundInterceptor):
+    async def execute_workflow(self, input: ExecuteWorkflowInput) -> Any:
+        # https://docs.sentry.io/platforms/python/troubleshooting/#addressing-concurrency-issues
+        with Hub(Hub.current):
+            set_tag("temporal.execution_type", "workflow")
+            set_tag("module", input.run_fn.__module__ + "." + input.run_fn.__qualname__)
+            workflow_info = workflow.info()
+            _set_common_workflow_tags(workflow_info)
+            set_tag("temporal.workflow.task_queue", workflow_info.task_queue)
+            set_tag("temporal.workflow.namespace", workflow_info.namespace)
+            set_tag("temporal.workflow.run_id", workflow_info.run_id)
+            try:
+                return await super().execute_workflow(input)
+            except Exception as e:
+                if len(input.args) == 1 and is_dataclass(input.args[0]):
+                    set_context("temporal.workflow.input", asdict(input.args[0]))
+                set_context("temporal.workflow.info", workflow.info().__dict__)
+
+                if not workflow.unsafe.is_replaying():
+                    capture_exception()
+                raise e
+
+
 class SentryInterceptor(Interceptor):
     """Temporal Interceptor class which will report workflow & activity exceptions to Sentry"""
 
@@ -51,3 +77,8 @@ class SentryInterceptor(Interceptor):
         :py:meth:`temporalio.worker.Interceptor.intercept_activity`.
         """
         return _SentryActivityInboundInterceptor(super().intercept_activity(next))
+
+    def workflow_interceptor_class(
+        self, input: WorkflowInterceptorClassInput
+    ) -> Optional[Type[WorkflowInboundInterceptor]]:
+        return _SentryWorkflowInterceptor

--- a/sentry/interceptor.py
+++ b/sentry/interceptor.py
@@ -63,7 +63,8 @@ class _SentryWorkflowInterceptor(WorkflowInboundInterceptor):
                 set_context("temporal.workflow.info", workflow.info().__dict__)
 
                 if not workflow.unsafe.is_replaying():
-                    capture_exception()
+                    with workflow.unsafe.sandbox_unrestricted():
+                        capture_exception()
                 raise e
 
 

--- a/sentry/interceptor.py
+++ b/sentry/interceptor.py
@@ -5,10 +5,7 @@ from temporalio import activity, workflow
 from temporalio.worker import (
     ActivityInboundInterceptor,
     ExecuteActivityInput,
-    ExecuteWorkflowInput,
     Interceptor,
-    WorkflowInboundInterceptor,
-    WorkflowInterceptorClassInput,
 )
 
 with workflow.unsafe.imports_passed_through():
@@ -44,29 +41,6 @@ class _SentryActivityInboundInterceptor(ActivityInboundInterceptor):
                 raise e
 
 
-class _SentryWorkflowInterceptor(WorkflowInboundInterceptor):
-    async def execute_workflow(self, input: ExecuteWorkflowInput) -> Any:
-        # https://docs.sentry.io/platforms/python/troubleshooting/#addressing-concurrency-issues
-        with Hub(Hub.current):
-            set_tag("temporal.execution_type", "workflow")
-            set_tag("module", input.run_fn.__module__ + "." + input.run_fn.__qualname__)
-            workflow_info = workflow.info()
-            _set_common_workflow_tags(workflow_info)
-            set_tag("temporal.workflow.task_queue", workflow_info.task_queue)
-            set_tag("temporal.workflow.namespace", workflow_info.namespace)
-            set_tag("temporal.workflow.run_id", workflow_info.run_id)
-            try:
-                return await super().execute_workflow(input)
-            except Exception as e:
-                if len(input.args) == 1 and is_dataclass(input.args[0]):
-                    set_context("temporal.workflow.input", asdict(input.args[0]))
-                set_context("temporal.workflow.info", workflow.info().__dict__)
-
-                if not workflow.unsafe.is_replaying():
-                    capture_exception()
-                raise e
-
-
 class SentryInterceptor(Interceptor):
     """Temporal Interceptor class which will report workflow & activity exceptions to Sentry"""
 
@@ -77,8 +51,3 @@ class SentryInterceptor(Interceptor):
         :py:meth:`temporalio.worker.Interceptor.intercept_activity`.
         """
         return _SentryActivityInboundInterceptor(super().intercept_activity(next))
-
-    def workflow_interceptor_class(
-        self, input: WorkflowInterceptorClassInput
-    ) -> Optional[Type[WorkflowInboundInterceptor]]:
-        return _SentryWorkflowInterceptor


### PR DESCRIPTION
even with suggested changes from https://github.com/temporalio/samples-python/pull/46 we are still getting `__call__ on threading.Lock restricted` warnings - this removes workflow interceptor to prevent those & related issues