### PR TITLE
Set Poetry version to 1.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,9 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python }}
-      - run: python -m pip install --upgrade wheel poetry poethepoet
+      # Using fixed Poetry version until
+      # https://github.com/python-poetry/poetry/pull/7694 is fixed
+      - run: python -m pip install --upgrade wheel "poetry==1.4.0" poethepoet
       - run: poetry install --with pydantic
       - run: poe lint
       - run: poe test -s -o log_cli_level=DEBUG


### PR DESCRIPTION
## What was changed

Latest Poetry 1.4.1 is breaking macOS builds with:

```
   _WheelFileValidationError

  ["In /Users/runner/Library/Caches/pypoetry/artifacts/59/74/28/0da99c4265a039049b4cccc0a54b5103991e1d78c7d85b899291d627c5/black-22.10.0-1fixedarch-cp310-cp310-macosx_11_0_x86_64.whl, hash / size of black-22.10.0.dist-info/WHEEL didn't match RECORD"]
```

Where it didn't before. So we fix the version to 1.4.0. This is a stopgap until https://github.com/python-poetry/poetry/pull/7694 is merged/released.