### PR TITLE
fix missing sleep to properly poll inside activity

### DIFF
--- a/polling/frequent/activities.py
+++ b/polling/frequent/activities.py
@@ -24,7 +24,7 @@ async def compose_greeting(input: ComposeGreetingInput) -> str:
                 return result
             except Exception as e:
                 # swallow exception since service is down
-                activity.logger.error(e)
+                activity.logger.debug("Failed, trying again shortly", exc_info=True)
 
             activity.heartbeat("Invoking activity")
             await asyncio.sleep(1)

--- a/polling/frequent/activities.py
+++ b/polling/frequent/activities.py
@@ -33,4 +33,3 @@ async def compose_greeting(input: ComposeGreetingInput) -> str:
             # if you need to clean up you can catch this.
             # Here we are just reraising the exception
             raise
-

--- a/polling/frequent/activities.py
+++ b/polling/frequent/activities.py
@@ -19,7 +19,7 @@ async def compose_greeting(input: ComposeGreetingInput) -> str:
     while True:
         try:
             try:
-                result = test_service.get_service_result(input)
+                result = await test_service.get_service_result(input)
                 activity.logger.info(f"Exiting activity ${result}")
                 return result
             except Exception as e:

--- a/polling/frequent/activities.py
+++ b/polling/frequent/activities.py
@@ -18,18 +18,19 @@ async def compose_greeting(input: ComposeGreetingInput) -> str:
     test_service = TestService()
     while True:
         try:
-            result = test_service.get_service_result(input)
-            activity.logger.info(f"Exiting activity ${result}")
-            return result
-        except Exception as e:
-            # swallow exception since service is down
-            activity.logger.error(e)
+            try:
+                result = test_service.get_service_result(input)
+                activity.logger.info(f"Exiting activity ${result}")
+                return result
+            except Exception as e:
+                # swallow exception since service is down
+                activity.logger.error(e)
 
-        try:
             activity.heartbeat("Invoking activity")
-        except asyncio.CancelledError as exception:
+            await asyncio.sleep(1)
+        except asyncio.CancelledError:
             # activity was either cancelled or workflow was completed or worker shut down
-            # if you need to clean up you can catch this. Here we are just reraising exception
+            # if you need to clean up you can catch this.
+            # Here we are just reraising the exception
             raise
 
-        await asyncio.sleep(1)

--- a/polling/frequent/activities.py
+++ b/polling/frequent/activities.py
@@ -1,6 +1,9 @@
+import asyncio
+import time
 from dataclasses import dataclass
 
 from temporalio import activity
+from temporalio.exceptions import CancelledError
 
 from polling.test_service import TestService
 
@@ -17,6 +20,16 @@ async def compose_greeting(input: ComposeGreetingInput) -> str:
     while True:
         try:
             result = test_service.get_service_result(input)
+            print(f"exiting activity ${result}")
             return result
-        except Exception:
+        except Exception as e:
+            # swallow exception since service is down
+            print(e)
+
+        try:
             activity.heartbeat("Invoking activity")
+        except CancelledError as exception:
+            # activity was either cancelled or workflow was completed or worker shut down
+            raise exception
+
+        await asyncio.sleep(1)

--- a/polling/test_service.py
+++ b/polling/test_service.py
@@ -3,7 +3,7 @@ class TestService:
         self.try_attempts = 0
         self.error_attempts = 5
 
-    def get_service_result(self, input):
+    async def get_service_result(self, input):
         print(
             f"Attempt {self.try_attempts}"
             f" of {self.error_attempts} to invoke service"


### PR DESCRIPTION
Current `frequent` polling implementation doesnt ever sleep after the mock service replies with a "service is down" Exception. This is supposed to be demonstrating polling _inside_ the activity so let's add back the sleep and handle heartbeat error upon cancellation correctly.