### PR TITLE
Updates for temporal CLI over tctl and temporal dev-server

### DIFF
--- a/encryption/README.md
+++ b/encryption/README.md
@@ -4,10 +4,6 @@ This sample shows how to make an encryption codec for end-to-end encryption. It 
 samples [in TypeScript](https://github.com/temporalio/samples-typescript/tree/main/encryption) and
 [in Go](https://github.com/temporalio/samples-go/tree/main/encryption).
 
-Ensure you have an environment variable set to the Namespace your Workflows are in:
-
-
-    export TEMPORAL_NAMESPACE=<Namespace Name>
 
 For this sample, the optional `encryption` dependency group must be included. To include, run:
 

--- a/encryption/README.md
+++ b/encryption/README.md
@@ -4,6 +4,11 @@ This sample shows how to make an encryption codec for end-to-end encryption. It 
 samples [in TypeScript](https://github.com/temporalio/samples-typescript/tree/main/encryption) and
 [in Go](https://github.com/temporalio/samples-go/tree/main/encryption).
 
+Ensure you have an environment variable set to the Namespace your Workflows are in:
+
+
+    export TEMPORAL_NAMESPACE=<Namespace Name>
+
 For this sample, the optional `encryption` dependency group must be included. To include, run:
 
     poetry install --with encryption
@@ -17,38 +22,34 @@ This will start the worker. Then, in another terminal, run the following to exec
 
     poetry run python starter.py
 
-The workflow should complete with the hello result. To view the workflow, use [tctl](https://docs.temporal.io/tctl-v1/):
+The workflow should complete with the hello result. To view the workflow, use [temporal](https://docs.temporal.io/cli):
 
-    tctl workflow show --workflow_id encryption-workflow-id
+    temporal workflow show --workflow-id encryption-workflow-id
 
-Note how the input/result look like (with wrapping removed):
+Note how the result looks like (with wrapping removed):
 
 ```
-    Input:[encoding binary/encrypted: payload encoding is not supported]
-    ...
-    Result:[encoding binary/encrypted: payload encoding is not supported]
+    Output:[encoding binary/encrypted: payload encoding is not supported]
 ```
 
-This is because the data is encrypted and not visible. To make data visible to external Temporal tools like `tctl` and
+This is because the data is encrypted and not visible. To make data visible to external Temporal tools like `temporal` and
 the UI, start a codec server in another terminal:
 
     poetry run python codec_server.py
 
-Now with that running, run `tctl` again with the codec endpoint:
+Now with that running, run `temporal` again with the codec endpoint:
 
-    tctl --codec_endpoint http://localhost:8081 workflow show --workflow_id encryption-workflow-id
+    temporal workflow show --workflow-id encryption-workflow-id --codec-endpoint http://localhost:8081
 
 Notice now the output has the unencrypted values:
 
 ```
-    Input:["Temporal"]
-    ...
     Result:["Hello, Temporal"]
 ```
 
 This decryption did not leave the local machine here.
 
 Same case with the web UI. If you go to the web UI, you'll only see encrypted input/results. But, assuming your web UI
-is at `http://localhost:8080`, if you set the "Remote Codec Endpoint" in the web UI to `http://localhost:8081` you can
+is at `http://localhost:8233` (this is the default for the local dev server), if you set the "Remote Codec Endpoint" in the web UI to `http://localhost:8081` you can
 then see the unencrypted results. This is possible because CORS settings in the codec server allow the browser to access
 the codec server directly over localhost. They can be changed to suit Temporal cloud web UI instead if necessary.

--- a/encryption/codec_server.py
+++ b/encryption/codec_server.py
@@ -12,8 +12,8 @@ def build_codec_server() -> web.Application:
     # Cors handler
     async def cors_options(req: web.Request) -> web.Response:
         resp = web.Response()
-        if req.headers.get(hdrs.ORIGIN) == "http://localhost:8080":
-            resp.headers[hdrs.ACCESS_CONTROL_ALLOW_ORIGIN] = "http://localhost:8080"
+        if req.headers.get(hdrs.ORIGIN) == "http://localhost:8233":
+            resp.headers[hdrs.ACCESS_CONTROL_ALLOW_ORIGIN] = "http://localhost:8233"
             resp.headers[hdrs.ACCESS_CONTROL_ALLOW_METHODS] = "POST"
             resp.headers[hdrs.ACCESS_CONTROL_ALLOW_HEADERS] = "content-type,x-namespace"
         return resp


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
I updated the README to use the ```temporal``` CLI instead of ```tctl``` and updated codec_server.py to default to port 8233 for the local web UI since that is the default port for ```temporal server start-dev```

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Tested on my local machine

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
Done
