### PR TITLE
Demonstrate workflow.all_handlers_finished

### DIFF
--- a/updates_and_signals/safe_message_handlers/README.md
+++ b/updates_and_signals/safe_message_handlers/README.md
@@ -4,9 +4,9 @@ This sample shows off important techniques for handling signals and updates, aka
 
 * Here, using workflow.wait_condition, signal and update handlers will only operate when the workflow is within a certain state--between cluster_started and cluster_shutdown.
 * You can run start_workflow with an initializer signal that you want to run before anything else other than the workflow's constructor.  This pattern is known as "signal-with-start."
-* Message handlers can block and their actions can be interleaved with one another and with the main workflow.  This can easily cause bugs, so we use a lock to protect shared state from interleaved access.
-* Message handlers should also finish before the workflow run completes.  One option is to use a lock.
-* An "Entity" workflow, i.e. a long-lived workflow, periodically "continues as new".  It must do this to prevent its history from growing too large, and it passes its state to the next workflow.  You can check `workflow.info().is_continue_as_new_suggested()` to see when it's time.  Just make sure message handlers have finished before doing so.  
+* Message handlers can block and their actions can be interleaved with one another and with the main workflow.  This can easily cause bugs, so you can use a lock to protect shared state from interleaved access.
+* An "Entity" workflow, i.e. a long-lived workflow, periodically "continues as new".  It must do this to prevent its history from growing too large, and it passes its state to the next workflow.  You can check `workflow.info().is_continue_as_new_suggested()` to see when it's time. 
+* Most people want their message handlers to finish before the workflow run completes or continues as new.  Use `await workflow.wait_condition(lambda: workflow.all_handlers_finished())` to achieve this.
 * Message handlers can be made idempotent.  See update `ClusterManager.assign_nodes_to_job`.
 
 To run, first see [README.md](../../README.md) for prerequisites.


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Before `workflow.all_handlers_finished` existed, I worked around it by checking a lock to see if we were in the middle of any handlers before continuing as new.
Now in 1.7, we can use the new method to prevent dangling handlers.

## Why?
<!-- Tell your future self why have you made these changes -->
Demonstrate what should become standard practice.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
```
# Terminal 1
cd updates_and_signals/safe_message_handlers
poetry run python ./worker.py
# Terminal 2
cd updates_and_signals/safe_message_handlers
poetry run python starter.py --test-continue-as-new
```
3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
Yes, see the README.md
