### PR TITLE
feat: add example using Sentry V2 SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .venv
 __pycache__
+.idea

--- a/poetry.lock
+++ b/poetry.lock
@@ -2128,21 +2128,22 @@ crt = ["botocore[crt] (>=1.33.2,<2.0a.0)"]
 
 [[package]]
 name = "sentry-sdk"
-version = "1.45.0"
+version = "2.13.0"
 description = "Python client for Sentry (https://sentry.io)"
 optional = false
-python-versions = "*"
+python-versions = ">=3.6"
 files = [
-    {file = "sentry-sdk-1.45.0.tar.gz", hash = "sha256:509aa9678c0512344ca886281766c2e538682f8acfa50fd8d405f8c417ad0625"},
-    {file = "sentry_sdk-1.45.0-py2.py3-none-any.whl", hash = "sha256:1ce29e30240cc289a027011103a8c83885b15ef2f316a60bcc7c5300afa144f1"},
+    {file = "sentry_sdk-2.13.0-py2.py3-none-any.whl", hash = "sha256:6beede8fc2ab4043da7f69d95534e320944690680dd9a963178a49de71d726c6"},
+    {file = "sentry_sdk-2.13.0.tar.gz", hash = "sha256:8d4a576f7a98eb2fdb40e13106e41f330e5c79d72a68be1316e7852cf4995260"},
 ]
 
 [package.dependencies]
 certifi = "*"
-urllib3 = {version = ">=1.26.11", markers = "python_version >= \"3.6\""}
+urllib3 = ">=1.26.11"
 
 [package.extras]
 aiohttp = ["aiohttp (>=3.5)"]
+anthropic = ["anthropic (>=0.16)"]
 arq = ["arq (>=0.23)"]
 asyncpg = ["asyncpg (>=0.23)"]
 beam = ["apache-beam (>=2.12)"]
@@ -2155,13 +2156,16 @@ django = ["django (>=1.8)"]
 falcon = ["falcon (>=1.4)"]
 fastapi = ["fastapi (>=0.79.0)"]
 flask = ["blinker (>=1.1)", "flask (>=0.11)", "markupsafe"]
-grpcio = ["grpcio (>=1.21.1)"]
+grpcio = ["grpcio (>=1.21.1)", "protobuf (>=3.8.0)"]
 httpx = ["httpx (>=0.16.0)"]
 huey = ["huey (>=2)"]
+huggingface-hub = ["huggingface-hub (>=0.22)"]
+langchain = ["langchain (>=0.0.210)"]
+litestar = ["litestar (>=2.0.0)"]
 loguru = ["loguru (>=0.5)"]
 openai = ["openai (>=1.0.0)", "tiktoken (>=0.3.0)"]
 opentelemetry = ["opentelemetry-distro (>=0.35b0)"]
-opentelemetry-experimental = ["opentelemetry-distro (>=0.40b0,<1.0)", "opentelemetry-instrumentation-aiohttp-client (>=0.40b0,<1.0)", "opentelemetry-instrumentation-django (>=0.40b0,<1.0)", "opentelemetry-instrumentation-fastapi (>=0.40b0,<1.0)", "opentelemetry-instrumentation-flask (>=0.40b0,<1.0)", "opentelemetry-instrumentation-requests (>=0.40b0,<1.0)", "opentelemetry-instrumentation-sqlite3 (>=0.40b0,<1.0)", "opentelemetry-instrumentation-urllib (>=0.40b0,<1.0)"]
+opentelemetry-experimental = ["opentelemetry-distro"]
 pure-eval = ["asttokens", "executing", "pure-eval"]
 pymongo = ["pymongo (>=3.1)"]
 pyspark = ["pyspark (>=2.4.4)"]
@@ -2171,7 +2175,7 @@ sanic = ["sanic (>=0.8)"]
 sqlalchemy = ["sqlalchemy (>=1.2)"]
 starlette = ["starlette (>=0.19.1)"]
 starlite = ["starlite (>=1.48)"]
-tornado = ["tornado (>=5)"]
+tornado = ["tornado (>=6)"]
 
 [[package]]
 name = "setuptools"
@@ -3041,4 +3045,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "1fa57ce5e51900d0a41e2d29bce3f9741752db46dcc5402616dd4a1daddd8084"
+content-hash = "c32ffcedef179eb4e16d0940340de040d10c94b7b262896997bc4048077f324b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,10 @@ dependencies = { pydantic = "^1.10.4" }
 
 [tool.poetry.group.sentry]
 optional = true
-dependencies = { sentry-sdk = "^1.11.0" }
+dependencies = { sentry-sdk = [
+        {version = "^1.11.0", python = "<3.6" },
+        {version = "^2.13.0", python = ">=3.6" }
+    ]}
 
 [tool.poe.tasks]
 format = [{cmd = "black ."}, {cmd = "isort ."}]

--- a/sentry_v2/README.md
+++ b/sentry_v2/README.md
@@ -1,0 +1,33 @@
+# Sentry V2 Sample
+
+This sample shows how to configure [Sentry](https://sentry.io) SDK V2 to intercept and capture errors from the Temporal SDK.
+
+Note: This is a small modification of the original example [sentry (v1)](../sentry) which seems to have
+issues in the Workflow interceptor, as there are modules (`warnings` and `threading`) that Sentry uses that aren't passed through
+to Temporal's sandbox properly, causing the Workflows to fail to execute.
+
+> Sentry V2 only supports Python 3.6 and higher. So if you're on Python 3.5, you may need to refer to the original example
+> (which doesn't work for me) or upgrade your Python version.
+
+### Further details
+
+Sentry's `Hub` object is now deprecated in the V2 SDK in favour of scopes. See [Activating Current Hub Clone](https://docs.sentry.io/platforms/python/migration/1.x-to-2.x#activating-current-hub-clone)
+for more details. The changes are  simple, just replace `with Hub(Hub.current):` with `with isolation_scope() as scope:`.
+
+## Running the Sample
+
+For this sample, the optional `sentry` dependency group must be included. To include, run:
+
+    poetry install --with sentry
+
+To run, first see [README.md](../README.md) for prerequisites. Set `SENTRY_DSN` environment variable to the Sentry DSN.
+Then, run the following from this directory to start the worker:
+
+    poetry run python worker.py
+
+This will start the worker. Then, in another terminal, run the following to execute the workflow:
+
+    poetry run python starter.py
+
+The workflow should complete with the hello result. If you alter the workflow or the activity to raise an
+`ApplicationError` instead, it should appear in Sentry.

--- a/sentry_v2/interceptor.py
+++ b/sentry_v2/interceptor.py
@@ -1,0 +1,85 @@
+from dataclasses import asdict, is_dataclass
+from typing import Any, Optional, Type, Union
+
+from temporalio import activity, workflow
+from temporalio.worker import (
+    ActivityInboundInterceptor,
+    ExecuteActivityInput,
+    ExecuteWorkflowInput,
+    Interceptor,
+    WorkflowInboundInterceptor,
+    WorkflowInterceptorClassInput,
+)
+
+with workflow.unsafe.imports_passed_through():
+    from sentry_sdk import isolation_scope, Scope
+
+
+def _set_common_workflow_tags(scope: Scope, info: Union[workflow.Info, activity.Info]):
+    scope.set_tag("temporal.workflow.type", info.workflow_type)
+    scope.set_tag("temporal.workflow.id", info.workflow_id)
+
+
+class _SentryActivityInboundInterceptor(ActivityInboundInterceptor):
+    async def execute_activity(self, input: ExecuteActivityInput) -> Any:
+        # https://docs.sentry.io/platforms/python/troubleshooting/#addressing-concurrency-issues
+        with isolation_scope() as scope:
+            scope.set_tag("temporal.execution_type", "activity")
+            scope.set_tag("module", input.fn.__module__ + "." + input.fn.__qualname__)
+
+            activity_info = activity.info()
+            _set_common_workflow_tags(scope, activity_info)
+            scope.set_tag("temporal.activity.id", activity_info.activity_id)
+            scope.set_tag("temporal.activity.type", activity_info.activity_type)
+            scope.set_tag("temporal.activity.task_queue", activity_info.task_queue)
+            scope.set_tag("temporal.workflow.namespace", activity_info.workflow_namespace)
+            scope.set_tag("temporal.workflow.run_id", activity_info.workflow_run_id)
+            try:
+                return await super().execute_activity(input)
+            except Exception as e:
+                if len(input.args) == 1 and is_dataclass(input.args[0]):
+                    scope.set_context("temporal.activity.input", asdict(input.args[0]))
+                scope.set_context("temporal.activity.info", activity.info().__dict__)
+                scope.capture_exception()
+                raise e
+
+
+class _SentryWorkflowInterceptor(WorkflowInboundInterceptor):
+    async def execute_workflow(self, input: ExecuteWorkflowInput) -> Any:
+        # https://docs.sentry.io/platforms/python/troubleshooting/#addressing-concurrency-issues
+        with isolation_scope() as scope:
+            scope.set_tag("temporal.execution_type", "workflow")
+            scope.set_tag("module", input.run_fn.__module__ + "." + input.run_fn.__qualname__)
+            workflow_info = workflow.info()
+            _set_common_workflow_tags(scope, workflow_info)
+            scope.set_tag("temporal.workflow.task_queue", workflow_info.task_queue)
+            scope.set_tag("temporal.workflow.namespace", workflow_info.namespace)
+            scope.set_tag("temporal.workflow.run_id", workflow_info.run_id)
+            try:
+                return await super().execute_workflow(input)
+            except Exception as e:
+                if len(input.args) == 1 and is_dataclass(input.args[0]):
+                    scope.set_context("temporal.workflow.input", asdict(input.args[0]))
+                scope.set_context("temporal.workflow.info", workflow.info().__dict__)
+
+                if not workflow.unsafe.is_replaying():
+                    with workflow.unsafe.sandbox_unrestricted():
+                        scope.capture_exception()
+                raise e
+
+
+class SentryInterceptor(Interceptor):
+    """Temporal Interceptor class which will report workflow & activity exceptions to Sentry"""
+
+    def intercept_activity(
+        self, next: ActivityInboundInterceptor
+    ) -> ActivityInboundInterceptor:
+        """Implementation of
+        :py:meth:`temporalio.worker.Interceptor.intercept_activity`.
+        """
+        return _SentryActivityInboundInterceptor(super().intercept_activity(next))
+
+    def workflow_interceptor_class(
+        self, input: WorkflowInterceptorClassInput
+    ) -> Optional[Type[WorkflowInboundInterceptor]]:
+        return _SentryWorkflowInterceptor

--- a/sentry_v2/starter.py
+++ b/sentry_v2/starter.py
@@ -1,0 +1,24 @@
+import asyncio
+import os
+
+from temporalio.client import Client
+
+from sentry.worker import GreetingWorkflow
+
+
+async def main():
+    # Connect client
+    client = await Client.connect("localhost:7233")
+
+    # Run workflow
+    result = await client.execute_workflow(
+        GreetingWorkflow.run,
+        "World",
+        id="sentry-workflow-id",
+        task_queue="sentry-task-queue",
+    )
+    print(f"Workflow result: {result}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/sentry_v2/worker.py
+++ b/sentry_v2/worker.py
@@ -1,0 +1,64 @@
+import asyncio
+import logging
+import os
+from dataclasses import dataclass
+from datetime import timedelta
+
+import sentry_sdk
+from temporalio import activity, workflow
+from temporalio.client import Client
+from temporalio.worker import Worker
+
+from sentry.interceptor import SentryInterceptor
+
+
+@dataclass
+class ComposeGreetingInput:
+    greeting: str
+    name: str
+
+
+@activity.defn
+async def compose_greeting(input: ComposeGreetingInput) -> str:
+    activity.logger.info("Running activity with parameter %s" % input)
+    return f"{input.greeting}, {input.name}!"
+
+
+@workflow.defn
+class GreetingWorkflow:
+    @workflow.run
+    async def run(self, name: str) -> str:
+        workflow.logger.info("Running workflow with parameter %s" % name)
+        return await workflow.execute_activity(
+            compose_greeting,
+            ComposeGreetingInput("Hello", name),
+            start_to_close_timeout=timedelta(seconds=10),
+        )
+
+
+async def main():
+    # Uncomment the line below to see logging
+    # logging.basicConfig(level=logging.INFO)
+
+    # Initialize the Sentry SDK
+    sentry_sdk.init(
+        dsn=os.environ.get("SENTRY_DSN"),
+    )
+
+    # Start client
+    client = await Client.connect("localhost:7233")
+
+    # Run a worker for the workflow
+    worker = Worker(
+        client,
+        task_queue="sentry-task-queue",
+        workflows=[GreetingWorkflow],
+        activities=[compose_greeting],
+        interceptors=[SentryInterceptor()],  # Use SentryInterceptor for error reporting
+    )
+
+    await worker.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Added a new example to set up Sentry using the V2 SDK.

## Why?
<!-- Tell your future self why have you made these changes -->

After recently trying to set up Sentry, the existing example that uses Sentry's V1 SDK doesn't work for me. The issue seems to be related to the `warnings` and `threading` modules that Sentry uses not being appropriately included in the Temporal Workflow's sandbox. This results in the Workflow execution failing to start in the worker that handles the Workflow. I don't see any issues with the Sentry interceptor on other workers that only handle activities, so it seems the problem is related to the Workflow sandbox.

Note: I also tried disabling the worker's sandbox, which seemed to get further. The workflow is able to start and eventually finish, but you get a sporadic error in the workflow's event history.

The solution is to migrate the interceptor to use V2 of Sentry's SDK, where the Hub object is now deprecated in favour of using scopes. Using the scope context manager doesn't seem to have the same issues with the warnings and threading libs (which it still uses).

I've created a new example to keep the V1 example in place, since V2 only works with Python 3.6 or above.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

https://temporalio.slack.com/archives/CTT84RS0P/p1725394300914329

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Tested manually in my application using Sentry.io

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

Added a new example with a README explaining the reasons/difference between the original example and the v2 example.