### PR TITLE
Dump junit XMLs from tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,9 @@ jobs:
       - run: python -m pip install --upgrade wheel "poetry==1.4.0" poethepoet
       - run: poetry install --with pydantic --with dsl --with encryption
       - run: poe lint
-      - run: poe test -s -o log_cli_level=DEBUG
-      - run: poe test -s -o log_cli_level=DEBUG --workflow-environment time-skipping
+      - run: mkdir junit-xml
+      - run: poe test -s -o log_cli_level=DEBUG --junit-xml=junit-xml/${{ matrix.python }}--${{ matrix.os }}.xml
+      - run: poe test -s -o log_cli_level=DEBUG --workflow-environment time-skipping --junit-xml=junit-xml/${{ matrix.python }}--${{ matrix.os }}--time-skipping.xml
 
       # On latest, run gevent test
       - name: Gevent test
@@ -51,4 +52,10 @@ jobs:
           poetry install --with gevent
           poetry run python gevent_async/test/run_combined.py
 
-
+      - name: Upload junit-xml artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: junit-xml--${{github.run_id}}--${{github.run_attempt}}--${{ matrix.python }}--${{ matrix.os }}
+          path: junit-xml
+          retention-days: 14


### PR DESCRIPTION
As in https://github.com/temporalio/sdk-python/pull/617, https://github.com/temporalio/cli/pull/650, https://github.com/temporalio/sdk-go/pull/1634, modify GitHub Actions CI workflow to dump junit XML files from test runs.