### PR TITLE
Cluster manager: use update to wait for cluster to start

### DIFF
--- a/message_passing/safe_message_handlers/README.md
+++ b/message_passing/safe_message_handlers/README.md
@@ -3,7 +3,6 @@
 This sample shows off important techniques for handling signals and updates, aka messages.  In particular, it illustrates how message handlers can interleave or not be completed before the workflow completes, and how you can manage that.
 
 * Here, using workflow.wait_condition, signal and update handlers will only operate when the workflow is within a certain state--between cluster_started and cluster_shutdown.
-* You can run start_workflow with an initializer signal that you want to run before anything else other than the workflow's constructor.  This pattern is known as "signal-with-start."
 * Message handlers can block and their actions can be interleaved with one another and with the main workflow.  This can easily cause bugs, so you can use a lock to protect shared state from interleaved access.
 * An "Entity" workflow, i.e. a long-lived workflow, periodically "continues as new".  It must do this to prevent its history from growing too large, and it passes its state to the next workflow.  You can check `workflow.info().is_continue_as_new_suggested()` to see when it's time. 
 * Most people want their message handlers to finish before the workflow run completes or continues as new.  Use `await workflow.wait_condition(lambda: workflow.all_handlers_finished())` to achieve this.

--- a/message_passing/safe_message_handlers/activities.py
+++ b/message_passing/safe_message_handlers/activities.py
@@ -11,6 +11,16 @@ class AssignNodesToJobInput:
     job_name: str
 
 
+@dataclass
+class ClusterState:
+    node_ids: List[str]
+
+
+@activity.defn
+async def start_cluster() -> ClusterState:
+    return ClusterState(node_ids=[f"{i}" for i in range(25)])
+
+
 @activity.defn
 async def assign_nodes_to_job(input: AssignNodesToJobInput) -> None:
     print(f"Assigning nodes {input.nodes} to job {input.job_name}")

--- a/message_passing/safe_message_handlers/activities.py
+++ b/message_passing/safe_message_handlers/activities.py
@@ -18,7 +18,7 @@ class ClusterState:
 
 @activity.defn
 async def start_cluster() -> ClusterState:
-    return ClusterState(node_ids=[f"{i}" for i in range(25)])
+    return ClusterState(node_ids=[f"node-{i}" for i in range(25)])
 
 
 @activity.defn
@@ -47,7 +47,7 @@ class FindBadNodesInput:
 @activity.defn
 async def find_bad_nodes(input: FindBadNodesInput) -> Set[str]:
     await asyncio.sleep(0.1)
-    bad_nodes = set([n for n in input.nodes_to_check if int(n) % 5 == 0])
+    bad_nodes = set([id for id in input.nodes_to_check if hash(id) % 5 == 0])
     if bad_nodes:
         print(f"Found bad nodes: {bad_nodes}")
     else:

--- a/message_passing/safe_message_handlers/starter.py
+++ b/message_passing/safe_message_handlers/starter.py
@@ -16,8 +16,10 @@ from message_passing.safe_message_handlers.workflow import (
 
 
 async def do_cluster_lifecycle(wf: WorkflowHandle, delay_seconds: Optional[int] = None):
-
-    await wf.signal(ClusterManagerWorkflow.start_cluster)
+    cluster_status = await wf.execute_update(
+        ClusterManagerWorkflow.wait_until_cluster_started
+    )
+    print(f"Cluster started with {len(cluster_status.nodes)} nodes")
 
     print("Assigning jobs to nodes...")
     allocation_updates = []

--- a/message_passing/safe_message_handlers/worker.py
+++ b/message_passing/safe_message_handlers/worker.py
@@ -8,6 +8,7 @@ from message_passing.safe_message_handlers.workflow import (
     ClusterManagerWorkflow,
     assign_nodes_to_job,
     find_bad_nodes,
+    start_cluster,
     unassign_nodes_for_job,
 )
 
@@ -21,7 +22,12 @@ async def main():
         client,
         task_queue="safe-message-handlers-task-queue",
         workflows=[ClusterManagerWorkflow],
-        activities=[assign_nodes_to_job, unassign_nodes_for_job, find_bad_nodes],
+        activities=[
+            assign_nodes_to_job,
+            unassign_nodes_for_job,
+            find_bad_nodes,
+            start_cluster,
+        ],
     ):
         logging.info("ClusterManagerWorkflow worker started, ctrl+c to exit")
         await interrupt_event.wait()

--- a/message_passing/safe_message_handlers/workflow.py
+++ b/message_passing/safe_message_handlers/workflow.py
@@ -74,13 +74,14 @@ class ClusterManagerWorkflow:
             self.state = ClusterManagerState()
 
         if input.test_continue_as_new:
-            self.max_history_length = 120
+            self.max_history_length: Optional[int] = 120
             self.sleep_interval_seconds = 1
+        else:
+            self.max_history_length = None
+            self.sleep_interval_seconds = 600
 
         # Protects workflow state from interleaved access
         self.nodes_lock = asyncio.Lock()
-        self.max_history_length: Optional[int] = None
-        self.sleep_interval_seconds: int = 600
 
     @workflow.update
     async def wait_until_cluster_started(self) -> ClusterManagerState:

--- a/tests/message_passing/safe_message_handlers/workflow_test.py
+++ b/tests/message_passing/safe_message_handlers/workflow_test.py
@@ -1,5 +1,6 @@
 import asyncio
 import uuid
+from typing import Callable, Sequence
 
 import pytest
 from temporalio.client import Client, WorkflowUpdateFailedError
@@ -20,7 +21,7 @@ from message_passing.safe_message_handlers.workflow import (
     ClusterManagerWorkflow,
 )
 
-ACTIVITIES = [
+ACTIVITIES: Sequence[Callable] = [
     assign_nodes_to_job,
     unassign_nodes_for_job,
     find_bad_nodes,


### PR DESCRIPTION
This PR changes our cluster manager sample as follows:

- Previously, the workflow was started, but the "cluster itself did not start" until a signal is sent in.
- Now, the workflow automatically does the "start cluster" operations on workflow start. An update is available for the user to wait until the cluster is ready to be used.

The reason for this change is that it highlights two styles of update usage:

1. The update accepts some input and does something with it (assign nodes to cluster, or execute an activity in general)
2. The update is used to wait until a certain stage (cluster started, early return available, etc)

In case (2) the workflow should generally be written such that it will orchestrate its work whether or not the update is sent, and that's what this PR does.

Also:
- switch to use `@workflow.init`
- Use `hash(node_id) % 5` instead of requiring node IDs to parse as ints