### PR TITLE
fix: periodic polling sample

### DIFF
--- a/polling/periodic_sequence/workflows.py
+++ b/polling/periodic_sequence/workflows.py
@@ -38,6 +38,7 @@ class ChildWorkflow:
             except ActivityError:
                 workflow.logger.error("Activity failed, retrying in 1 seconds")
             await asyncio.sleep(1)
-            workflow.continue_as_new(name)
 
-        raise Exception("Polling failed after all attempts")
+        workflow.continue_as_new(name)
+        # unreachable
+        return ""


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Fixed the retry loop in the "Periodic Polling of a Sequence of Activities" example.


## Why?
Previously, `continue_as_new` was inside the retry loop, causing the workflow to restart after just **one failed attempt**, instead of retrying up to 10 times as intended.


## Checklist
<!--- add/delete as needed --->

1. Closes #182 

2. How was this tested:
Manually tested by running the workflow and verifying that it retries 10 times before continuing as new. Also validated expected logging behavior.


3. Any docs updates needed?
No updates needed.
