### PR TITLE
Properly skip infrequent polling test on time-skipping server

### DIFF
--- a/tests/polling/infrequent/workflow_test.py
+++ b/tests/polling/infrequent/workflow_test.py
@@ -10,7 +10,7 @@ from polling.infrequent.workflows import GreetingWorkflow
 
 
 async def test_infrequent_polling_workflow(client: Client, env: WorkflowEnvironment):
-    if not env.supports_time_skipping:
+    if env.supports_time_skipping:
         pytest.skip("Too slow to test with time-skipping disabled")
 
     # Start a worker that hosts the workflow and activity implementations.


### PR DESCRIPTION
## What was changed

Properly skip infrequent polling test on time-skipping server

## Checklist

1. Closes #184