### PR TITLE
Add sample workflow for reauthentication after risk event

### DIFF
--- a/reauth_after_risk_event/starter.py
+++ b/reauth_after_risk_event/starter.py
@@ -1,0 +1,19 @@
+import asyncio
+from datetime import timedelta
+from temporalio.client import Client
+
+async def main():
+    client = await Client.connect("localhost:7233")
+
+    result = await client.start_workflow(
+        "ReauthenticationAfterRiskEventWorkflow",
+        "user-123",  # user_id
+        id="reauth-workflow-user-123",
+        task_queue="reauth-task-queue",
+        run_timeout=timedelta(minutes=1),  # Correct timeout usage
+    )
+
+    print(f"Started workflow. Run ID: {result.id}")
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/reauth_after_risk_event/worker.py
+++ b/reauth_after_risk_event/worker.py
@@ -1,0 +1,17 @@
+import asyncio
+from temporalio.worker import Worker
+from temporalio.client import Client
+from workflow import ReauthenticationAfterRiskEventWorkflow
+
+async def main():
+    client = await Client.connect("localhost:7233")
+    worker = Worker(
+        client,
+        task_queue="reauth-task-queue",
+        workflows=[ReauthenticationAfterRiskEventWorkflow],
+    )
+    print("Worker started.")
+    await worker.run()
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/reauth_after_risk_event/workflow.py
+++ b/reauth_after_risk_event/workflow.py
@@ -1,0 +1,29 @@
+from datetime import timedelta
+from temporalio import workflow
+
+# Signal to be sent when user completes reauthentication
+@workflow.defn
+class ReauthenticationAfterRiskEventWorkflow:
+    def __init__(self):
+        self.reauthenticated = False
+
+    @workflow.signal
+    async def complete_reauthentication(self):
+        self.reauthenticated = True
+
+    @workflow.run
+    async def run(self, user_id: str, timeout_minutes: int = 10) -> str:
+        workflow.logger.info(f"Started reauth workflow for user: {user_id}")
+
+        # Wait for signal or timeout
+        try:
+            await workflow.wait_condition(
+                lambda: self.reauthenticated,
+                timeout=timedelta(minutes=timeout_minutes)
+            )
+        except TimeoutError:
+            workflow.logger.warn("Timeout waiting for reauthentication")
+            return "failed_timeout"
+
+        workflow.logger.info("User successfully reauthenticated")
+        return "success"


### PR DESCRIPTION
## 🛠 What was changed

Added a new sample workflow: `ReauthenticationAfterRiskEventWorkflow`.  
This workflow demonstrates an adaptive authentication pattern where users are required to reauthenticate after suspicious activity — such as login from a new device or after completing account recovery.  

The worker listens for a `reauth_complete` signal, and the workflow can be configured with a timeout to handle cases where reauthentication isn't completed in time.

## 🔐 Why?

This use case is relevant for security-conscious applications that need to enforce reauthentication following risk events.  
The sample highlights how Temporal can model secure, stateful authentication workflows that are durable, auditable, and cleanly separated from business logic.

It aligns with modern security practices around risk-based session validation and account protection.

## ✅ Checklist

- [x] New sample added to `samples-python`
- [x] Demonstrates secure workflow pattern using Temporal signals and timeouts
- [x] Includes worker and starter code for demonstration


## Notes

There wasn’t a separate issue filed for this PR.  
If preferred, I can open one and link it here for tracking purposes.

Let me know if any adjustments are needed!
