### PR TITLE
change patching to use start_to_close

### DIFF
--- a/patching/workflow_1_initial.py
+++ b/patching/workflow_1_initial.py
@@ -12,7 +12,7 @@ class MyWorkflow:
     async def run(self) -> None:
         self._result = await workflow.execute_activity(
             pre_patch_activity,
-            schedule_to_close_timeout=timedelta(minutes=5),
+            start_to_close_timeout=timedelta(seconds=5),
         )
 
     @workflow.query

--- a/patching/workflow_2_patched.py
+++ b/patching/workflow_2_patched.py
@@ -13,12 +13,12 @@ class MyWorkflow:
         if workflow.patched("my-patch"):
             self._result = await workflow.execute_activity(
                 post_patch_activity,
-                schedule_to_close_timeout=timedelta(minutes=5),
+                start_to_close_timeout=timedelta(seconds=5),
             )
         else:
             self._result = await workflow.execute_activity(
                 pre_patch_activity,
-                schedule_to_close_timeout=timedelta(minutes=5),
+                start_to_close_timeout=timedelta(seconds=5),
             )
 
     @workflow.query

--- a/patching/workflow_3_patch_deprecated.py
+++ b/patching/workflow_3_patch_deprecated.py
@@ -13,7 +13,7 @@ class MyWorkflow:
         workflow.deprecate_patch("my-patch")
         self._result = await workflow.execute_activity(
             post_patch_activity,
-            schedule_to_close_timeout=timedelta(minutes=5),
+            start_to_close_timeout=timedelta(seconds=5),
         )
 
     @workflow.query

--- a/patching/workflow_4_patch_complete.py
+++ b/patching/workflow_4_patch_complete.py
@@ -12,7 +12,7 @@ class MyWorkflow:
     async def run(self) -> None:
         self._result = await workflow.execute_activity(
             post_patch_activity,
-            schedule_to_close_timeout=timedelta(minutes=5),
+            start_to_close_timeout=timedelta(seconds=5),
         )
 
     @workflow.query


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->


With schedule_to_close, if the developer restarts the worker after the activity is scheduled, the activity will throw a non-retriable error after 5 minutes. 

Changed to start_to_close to make the activity failure retriable




## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
