### PR TITLE
VLN-537: Set explicit permissions for GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,7 @@
 name: Continuous Integration
+permissions:
+  contents: read
+  actions: write
 on: # rebuild any PRs and main branch changes
   pull_request:
   push:


### PR DESCRIPTION
## Summary

- `.github/workflows/ci.yml`: Added a top-level permissions block in .github/workflows/ci.yml:2 granting only contents: read and actions: write so checkout works while artifact uploads retain required access.