### PR TITLE
AI-18: Move set_tracing_disabled from workflow to worker startup

### DIFF
--- a/openai_agents/model_providers/run_gpt_oss_worker.py
+++ b/openai_agents/model_providers/run_gpt_oss_worker.py
@@ -27,6 +27,9 @@ class CustomModelProvider(ModelProvider):
 
 
 async def main():
+    # Disable Agents SDK tracing — the default exporter sends traces to OpenAI's
+    # backend, which requires an OpenAI API key not available in these samples.
+    # Call here rather than in the workflow because it's a global side effect.
     set_tracing_disabled(disabled=True)
 
     # Configure logging to show workflow debug messages

--- a/openai_agents/model_providers/run_gpt_oss_worker.py
+++ b/openai_agents/model_providers/run_gpt_oss_worker.py
@@ -3,7 +3,12 @@ import logging
 from datetime import timedelta
 from typing import Optional
 
-from agents import Model, ModelProvider, OpenAIChatCompletionsModel, set_tracing_disabled
+from agents import (
+    Model,
+    ModelProvider,
+    OpenAIChatCompletionsModel,
+    set_tracing_disabled,
+)
 from openai import AsyncOpenAI
 from temporalio.client import Client
 from temporalio.contrib.openai_agents import ModelActivityParameters, OpenAIAgentsPlugin

--- a/openai_agents/model_providers/run_gpt_oss_worker.py
+++ b/openai_agents/model_providers/run_gpt_oss_worker.py
@@ -3,7 +3,7 @@ import logging
 from datetime import timedelta
 from typing import Optional
 
-from agents import Model, ModelProvider, OpenAIChatCompletionsModel
+from agents import Model, ModelProvider, OpenAIChatCompletionsModel, set_tracing_disabled
 from openai import AsyncOpenAI
 from temporalio.client import Client
 from temporalio.contrib.openai_agents import ModelActivityParameters, OpenAIAgentsPlugin
@@ -27,6 +27,8 @@ class CustomModelProvider(ModelProvider):
 
 
 async def main():
+    set_tracing_disabled(disabled=True)
+
     # Configure logging to show workflow debug messages
     logging.basicConfig(level=logging.WARNING)
     logging.getLogger("temporalio.workflow").setLevel(logging.DEBUG)

--- a/openai_agents/model_providers/run_litellm_provider_worker.py
+++ b/openai_agents/model_providers/run_litellm_provider_worker.py
@@ -1,6 +1,7 @@
 import asyncio
 from datetime import timedelta
 
+from agents import set_tracing_disabled
 from agents.extensions.models.litellm_provider import LitellmProvider
 from temporalio.client import Client
 from temporalio.contrib.openai_agents import ModelActivityParameters, OpenAIAgentsPlugin
@@ -12,6 +13,8 @@ from openai_agents.model_providers.workflows.litellm_auto_workflow import (
 
 
 async def main():
+    set_tracing_disabled(disabled=True)
+
     # Create client connected to server at the given address
     client = await Client.connect(
         "localhost:7233",

--- a/openai_agents/model_providers/run_litellm_provider_worker.py
+++ b/openai_agents/model_providers/run_litellm_provider_worker.py
@@ -13,6 +13,9 @@ from openai_agents.model_providers.workflows.litellm_auto_workflow import (
 
 
 async def main():
+    # Disable Agents SDK tracing — the default exporter sends traces to OpenAI's
+    # backend, which requires an OpenAI API key not available in these samples.
+    # Call here rather than in the workflow because it's a global side effect.
     set_tracing_disabled(disabled=True)
 
     # Create client connected to server at the given address

--- a/openai_agents/model_providers/workflows/gpt_oss_workflow.py
+++ b/openai_agents/model_providers/workflows/gpt_oss_workflow.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from agents import Agent, Runner, function_tool, set_tracing_disabled
+from agents import Agent, Runner, function_tool
 from temporalio import workflow
 
 
@@ -8,8 +8,6 @@ from temporalio import workflow
 class GptOssWorkflow:
     @workflow.run
     async def run(self, prompt: str) -> str:
-        set_tracing_disabled(disabled=True)
-
         @function_tool
         def get_weather(city: str):
             workflow.logger.debug(f"Getting weather for {city}")

--- a/openai_agents/model_providers/workflows/litellm_auto_workflow.py
+++ b/openai_agents/model_providers/workflows/litellm_auto_workflow.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from agents import Agent, Runner, function_tool, set_tracing_disabled
+from agents import Agent, Runner, function_tool
 from temporalio import workflow
 
 
@@ -8,8 +8,6 @@ from temporalio import workflow
 class LitellmAutoWorkflow:
     @workflow.run
     async def run(self, prompt: str) -> str:
-        set_tracing_disabled(disabled=True)
-
         @function_tool
         def get_weather(city: str):
             return f"The weather in {city} is sunny."


### PR DESCRIPTION
## Summary

- Moved `set_tracing_disabled(disabled=True)` out of workflow `run()` methods and into worker `main()` functions in the `openai_agents/model_providers/` samples
- `set_tracing_disabled` is a global side effect that shouldn't live inside deterministic workflow code — it belongs at worker startup where it runs once per process

Fixes #243