### PR TITLE
chore: Update and pin all GHA actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,13 @@ jobs:
             runsOn: macos-latest
     runs-on: ${{ matrix.runsOn || matrix.os }}
     steps:
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8
       - name: Print build information
         run: "echo head_ref: ${{ github.head_ref }}, ref: ${{ github.ref }}, os: ${{ matrix.os }}, python: ${{ matrix.python }}"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           submodules: recursive
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ matrix.python }}
       - run: uv tool install poethepoet
@@ -56,7 +56,7 @@ jobs:
           uv run gevent_async/test/run_combined.py
 
       - name: Upload junit-xml artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         if: always()
         with:
           name: junit-xml--${{github.run_id}}--${{github.run_attempt}}--${{ matrix.python }}--${{ matrix.os }}


### PR DESCRIPTION
## What changed

- Bump all GitHub Actions workflows to use latest "safe" releases.
  "Safe" is defined as the latest published release that is at least 2 weeks old (cooldown period).
- Pin all GHA actions usage to full SHA1, with a version comment.

## Why

- Improved security.
