### PR TITLE
Fix display of activity list results

### DIFF
--- a/hello_standalone_activity/list_activities.py
+++ b/hello_standalone_activity/list_activities.py
@@ -15,7 +15,7 @@ async def my_application():
 
     async for info in activities:
         print(
-            f"ActivityID: {info.activity_id}, Type: {info.activity_type}, Status: {info.status}"
+            f"ActivityID: {info.activity_id}, Type: {info.activity_type}, Status: {info.status.name}"
         )
 
 


### PR DESCRIPTION
## What was changed
Print name of enum variant.

## Why?
It was what was intended.

**Before**
```
samples-python(main)  uv run hello_standalone_activity/list_activities.py
ActivityID: my-standalone-activity-id, Type: compose_greeting, Status: 2
ActivityID: my-standalone-activity-id, Type: compose_greeting, Status: 2
ActivityID: my-standalone-activity-id, Type: compose_greeting, Status: 2
```

**After**

```
samples-python(saa-sample-tweak) uv run hello_standalone_activity/list_activities.py
ActivityID: my-standalone-activity-id, Type: compose_greeting, Status: COMPLETED
ActivityID: my-standalone-activity-id, Type: compose_greeting, Status: COMPLETED
ActivityID: my-standalone-activity-id, Type: compose_greeting, Status: COMPLETED
```
