### PR TITLE
Nexus samples: use business IDs for workflow IDs

### DIFF
--- a/hello_nexus/handler/service_handler.py
+++ b/hello_nexus/handler/service_handler.py
@@ -33,7 +33,7 @@ class MyNexusServiceHandler:
         return await ctx.start_workflow(
             WorkflowStartedByNexusOperation.run,
             input,
-            id=str(uuid.uuid4()),
+            id=f"hello-nexus-workflow-{input.name}-{uuid.uuid4()}",
         )
 
     # This is a Nexus operation that responds synchronously to all requests. That means

--- a/hello_nexus/handler/service_handler.py
+++ b/hello_nexus/handler/service_handler.py
@@ -4,8 +4,6 @@ This file demonstrates how to implement a Nexus service.
 
 from __future__ import annotations
 
-import uuid
-
 import nexusrpc
 from temporalio import nexus
 
@@ -33,7 +31,7 @@ class MyNexusServiceHandler:
         return await ctx.start_workflow(
             WorkflowStartedByNexusOperation.run,
             input,
-            id=f"hello-nexus-workflow-{input.name}-{uuid.uuid4()}",
+            id=f"hello-nexus-workflow-{input.name}",
         )
 
     # This is a Nexus operation that responds synchronously to all requests. That means

--- a/nexus_cancel/handler/service_handler.py
+++ b/nexus_cancel/handler/service_handler.py
@@ -1,11 +1,14 @@
 """
 Nexus service handler for the cancellation sample.
 
-The hello operation is backed by a workflow, using the Nexus request ID as the
-workflow ID for idempotency across retries.
+The hello operation is backed by a workflow whose ID is derived from the
+operation input (name + language), giving each fan-out branch a distinct,
+meaningful business ID.
 """
 
 from __future__ import annotations
+
+import uuid
 
 import nexusrpc
 from temporalio import nexus
@@ -23,5 +26,5 @@ class NexusServiceHandler:
         return await ctx.start_workflow(
             HelloHandlerWorkflow.run,
             input,
-            id=ctx.request_id,
+            id=f"hello-handler-{input.name}-{input.language.name}-{uuid.uuid4()}",
         )

--- a/nexus_cancel/handler/service_handler.py
+++ b/nexus_cancel/handler/service_handler.py
@@ -8,8 +8,6 @@ meaningful business ID.
 
 from __future__ import annotations
 
-import uuid
-
 import nexusrpc
 from temporalio import nexus
 
@@ -26,5 +24,5 @@ class NexusServiceHandler:
         return await ctx.start_workflow(
             HelloHandlerWorkflow.run,
             input,
-            id=f"hello-handler-{input.name}-{input.language.name}-{uuid.uuid4()}",
+            id=f"hello-handler-{input.name}-{input.language.name}",
         )

--- a/nexus_multiple_args/handler/service_handler.py
+++ b/nexus_multiple_args/handler/service_handler.py
@@ -32,7 +32,7 @@ class MyNexusServiceHandler:
                 input.name,  # First argument: name
                 input.language,  # Second argument: language
             ],
-            id=str(uuid.uuid4()),
+            id=f"hello-multi-args-{input.name}-{input.language}-{uuid.uuid4()}",
         )
 
 

--- a/nexus_multiple_args/handler/service_handler.py
+++ b/nexus_multiple_args/handler/service_handler.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import uuid
-
 import nexusrpc
 from temporalio import nexus
 
@@ -32,7 +30,7 @@ class MyNexusServiceHandler:
                 input.name,  # First argument: name
                 input.language,  # Second argument: language
             ],
-            id=f"hello-multi-args-{input.name}-{input.language}-{uuid.uuid4()}",
+            id=f"hello-multi-args-{input.name}-{input.language}",
         )
 
 


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->

Stop using the Nexus request ID (nexus_cancel) or bare uuid4 (hello_nexus, nexus_multiple_args) as the backing workflow ID. Build a meaningful business ID from the operation input.

## Why?
<!-- Tell your future self why have you made these changes -->

Our samples should reflect best practices around creating meaningful IDs. Part of https://github.com/temporalio/features/issues/692.

