### PR TITLE
AI-180: Disable LangSmith network calls in samples tests via mock client

### DIFF
--- a/tests/langsmith_tracing/conftest.py
+++ b/tests/langsmith_tracing/conftest.py
@@ -1,0 +1,21 @@
+"""Shared fixtures for LangSmith tracing tests."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def mock_ls_client() -> MagicMock:
+    """Return a mock ``langsmith.Client`` that never makes network calls.
+
+    The samples tests don't assert on trace output — the LangSmith plugin
+    just needs *some* client object to wire into the worker.  ``MagicMock``
+    auto-stubs every method the interceptor calls; the explicit ``session``
+    and ``tracing_queue`` stubs match what the langsmith library touches
+    internally.
+    """
+    client = MagicMock()
+    client.session = MagicMock()
+    client.tracing_queue = MagicMock()
+    return client

--- a/tests/langsmith_tracing/test_basic.py
+++ b/tests/langsmith_tracing/test_basic.py
@@ -1,4 +1,5 @@
 import uuid
+from unittest.mock import MagicMock
 
 from temporalio import activity
 from temporalio.client import Client
@@ -10,7 +11,9 @@ from langsmith_tracing.basic.activities import OpenAIRequest
 from langsmith_tracing.basic.workflows import BasicLLMWorkflow
 
 
-async def test_basic_workflow(client: Client, env: WorkflowEnvironment):
+async def test_basic_workflow(
+    client: Client, env: WorkflowEnvironment, mock_ls_client: MagicMock
+):
     expected_text = "Temporal is a durable execution platform."
 
     @activity.defn(name="call_openai")
@@ -22,7 +25,7 @@ async def test_basic_workflow(client: Client, env: WorkflowEnvironment):
         task_queue="test-langsmith-basic",
         workflows=[BasicLLMWorkflow],
         activities=[mock_call_openai],
-        plugins=[LangSmithPlugin()],
+        plugins=[LangSmithPlugin(client=mock_ls_client)],
     ):
         result = await client.execute_workflow(
             BasicLLMWorkflow.run,

--- a/tests/langsmith_tracing/test_chatbot.py
+++ b/tests/langsmith_tracing/test_chatbot.py
@@ -1,5 +1,6 @@
 import json
 import uuid
+from unittest.mock import MagicMock
 
 from temporalio import activity
 from temporalio.client import Client
@@ -27,7 +28,9 @@ def _make_function_call_response(
     )
 
 
-async def test_chatbot_save_note(client: Client, env: WorkflowEnvironment):
+async def test_chatbot_save_note(
+    client: Client, env: WorkflowEnvironment, mock_ls_client: MagicMock
+):
     """Test save_note tool call loop — save_note runs as a workflow method."""
     call_count = 0
 
@@ -47,7 +50,7 @@ async def test_chatbot_save_note(client: Client, env: WorkflowEnvironment):
         task_queue="test-langsmith-chatbot",
         workflows=[ChatbotWorkflow],
         activities=[mock_call_openai],
-        plugins=[LangSmithPlugin()],
+        plugins=[LangSmithPlugin(client=mock_ls_client)],
     ):
         wf_handle = await client.start_workflow(
             ChatbotWorkflow.run,
@@ -68,8 +71,10 @@ async def test_chatbot_save_note(client: Client, env: WorkflowEnvironment):
         assert result == "Session ended."
 
 
-async def test_chatbot_read_note(client: Client, env: WorkflowEnvironment):
-    """Test read_note tool call loop — read_note runs as a workflow method."""
+async def test_chatbot_read_note(
+    client: Client, env: WorkflowEnvironment, mock_ls_client: MagicMock
+):
+    """Test read_note tool call loop — saves a note first, then reads it back."""
     call_count = 0
 
     @activity.defn(name="call_openai")
@@ -97,7 +102,7 @@ async def test_chatbot_read_note(client: Client, env: WorkflowEnvironment):
         task_queue="test-langsmith-chatbot-read",
         workflows=[ChatbotWorkflow],
         activities=[mock_call_openai],
-        plugins=[LangSmithPlugin()],
+        plugins=[LangSmithPlugin(client=mock_ls_client)],
     ):
         wf_handle = await client.start_workflow(
             ChatbotWorkflow.run,


### PR DESCRIPTION
## Summary

- `tests/langsmith_tracing/test_basic.py` and `test_chatbot.py` previously instantiated `LangSmithPlugin()` with no client. Internally that constructs a real `langsmith.Client` which authenticates against `api.smith.langchain.com` using whatever `LANGSMITH_API_KEY` is in env, producing 401/403 warnings on every test run when a stale key was present.
- Added a `mock_ls_client` pytest fixture (in a new `tests/langsmith_tracing/conftest.py`) and wired it into both tests via `LangSmithPlugin(client=mock_ls_client)`. The mock is a `MagicMock` with explicit `.session` and `.tracing_queue` stubs that the langsmith library accesses internally.
- Verified empirically with `pytest-socket --disable-socket --allow-hosts=127.0.0.1,::1,localhost` and `LANGSMITH_API_KEY` set: zero non-localhost connections attempted, even with the env var present.
- Drive-by: corrected a pre-existing docstring on `test_chatbot_read_note` that didn't mention the save-first phase of the test.

## Related

- [AI-183](https://temporalio.atlassian.net/browse/AI-183) tracks the underlying SDK bug — `LangSmithInterceptor` force-sets `tracing_context(enabled=True)`, which overrides `LANGSMITH_TRACING=false`. That's why the env-var disable mechanism couldn't be used here and a mock client is the correct fix in the samples.

## Test plan

- [x] `uv run --group langsmith-tracing pytest tests/langsmith_tracing/ -v` — 3/3 pass
- [x] `uv run ruff check tests/langsmith_tracing/` — clean
- [x] `uv run ruff format --check tests/langsmith_tracing/` — clean
- [x] No network I/O verified via `pytest-socket --disable-socket --allow-hosts=127.0.0.1,::1,localhost` with `LANGSMITH_API_KEY` set


[AI-183]: https://temporalio.atlassian.net/browse/AI-183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ