### PR TITLE
VLN-1384: remediate missing-dependency-cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 14
+
+  - package-ecosystem: "uv"
+    directory: "/lambda_worker"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 14
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 14

--- a/lambda_worker/pyproject.toml
+++ b/lambda_worker/pyproject.toml
@@ -19,6 +19,9 @@ dev = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.uv]
+exclude-newer = "14 days"
+
 [tool.hatch.metadata]
 allow-direct-references = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,9 @@ packages = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.uv]
+exclude-newer = "14 days"
+
 [tool.poe.tasks]
 format = [
     { cmd = "uv run ruff check --select I --fix" },


### PR DESCRIPTION
> 🏕️ This pull request was created by [camper](https://github.com/temporalio/camper), an automated security campaign tool.

## Finding

<table>
  <tr><td><strong>Rule</strong></td><td><code>missing-dependency-cooldown</code></td></tr>
  <tr><td><strong>Severity</strong></td><td>MEDIUM</td></tr>
  <tr><td><strong>Repository</strong></td><td><code>temporalio/samples-python</code></td></tr>
  <tr><td><strong>Ticket</strong></td><td><a href="https://temporalio.atlassian.net/browse/VLN-1384">VLN-1384</a></td></tr>
</table>

## Summary

- `pyproject.toml`: Added native `uv` dependency cooldown by introducing `[tool.uv]` with `exclude-newer = "14 days"`.
- `lambda_worker/pyproject.toml`: Added native `uv` dependency cooldown by introducing `[tool.uv]` with `exclude-newer = "14 days"` for the lambda worker project.
- `.github/dependabot.yml`: Created Dependabot configuration with weekly updates and `cooldown.default-days: 14` for `uv` (root and `lambda_worker`) and `github-actions` ecosystems.

## Instructions

- **Approve** to merge this fix
- **Request changes** to trigger a new remediation attempt
- `/camper rebase` — rebase onto the base branch
- `/camper close` — close this PR without merging
- `/camper retry` — close and retry with a new fix