### PR TITLE
Use datetime.timedelta in openai_agents samples

### DIFF
--- a/openai_agents/basic/workflows/local_image_workflow.py
+++ b/openai_agents/basic/workflows/local_image_workflow.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from agents import Agent, Runner
 from temporalio import workflow
 
@@ -24,7 +26,7 @@ class LocalImageWorkflow:
         b64_image = await workflow.execute_activity(
             read_image_as_base64,
             image_path,
-            start_to_close_timeout=workflow.timedelta(seconds=30),
+            start_to_close_timeout=timedelta(seconds=30),
         )
 
         agent = Agent(

--- a/openai_agents/reasoning_content/workflows/reasoning_content_workflow.py
+++ b/openai_agents/reasoning_content/workflows/reasoning_content_workflow.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from datetime import timedelta
 
 from temporalio import workflow
 
@@ -22,7 +23,7 @@ class ReasoningContentWorkflow:
         reasoning_content, regular_content = await workflow.execute_activity(
             get_reasoning_response,
             args=[prompt, model_name],
-            start_to_close_timeout=workflow.timedelta(minutes=5),
+            start_to_close_timeout=timedelta(minutes=5),
         )
 
         return ReasoningResult(


### PR DESCRIPTION
## Summary
- `workflow.timedelta` was an incidental re-export from temporalio's old `workflow.py` module. The refactor in [temporalio/sdk-python#1488](https://github.com/temporalio/sdk-python/pull/1488) split it into a package and dropped that name.
- Switch the two affected samples (`openai_agents/basic/workflows/local_image_workflow.py` and `openai_agents/reasoning_content/workflows/reasoning_content_workflow.py`) to `datetime.timedelta`, matching the rest of the repo.

## Test plan
- [x] `uv run poe lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)