### PR TITLE
AI-284: Add snipsync markers and trim comments in ADK samples

### DIFF
--- a/google_adk_agents/agent_patterns/run_worker.py
+++ b/google_adk_agents/agent_patterns/run_worker.py
@@ -12,8 +12,6 @@ from google_adk_agents.agent_patterns.workflows.multi_agent_workflow import (
 
 
 async def main():
-    # Build the plugin once and give the same instance to the client and the
-    # worker.
     plugin = GoogleAdkPlugin()
 
     client = await Client.connect("localhost:7233", plugins=[plugin])

--- a/google_adk_agents/agent_patterns/workflows/multi_agent_workflow.py
+++ b/google_adk_agents/agent_patterns/workflows/multi_agent_workflow.py
@@ -19,8 +19,8 @@ class MultiAgentWorkflow:
             app_name="multi_agent_app", user_id="user"
         )
 
-        # Give each sub-agent its own TemporalModel with an ActivityConfig
-        # summary, so its model turns show up as named activities in history.
+        # The ActivityConfig summary makes each model turn a named activity in
+        # history.
         researcher = LlmAgent(
             name="researcher",
             model=TemporalModel(
@@ -39,8 +39,7 @@ class MultiAgentWorkflow:
             instruction="You are a poet. Write a haiku based on the research.",
         )
 
-        # The coordinator hands off to the sub-agents using ADK's built-in
-        # transfer_to_agent, which runs durably here.
+        # ADK's transfer_to_agent handoff runs durably here.
         coordinator = LlmAgent(
             name="coordinator",
             model=TemporalModel(

--- a/google_adk_agents/basic/run_hello_world_workflow.py
+++ b/google_adk_agents/basic/run_hello_world_workflow.py
@@ -9,6 +9,7 @@ from google_adk_agents.basic.workflows.hello_world_workflow import (
 
 
 async def main():
+    # @@@SNIPSTART google-adk-agents-basic-starter
     client = await Client.connect("localhost:7233", plugins=[GoogleAdkPlugin()])
 
     result = await client.execute_workflow(
@@ -18,6 +19,7 @@ async def main():
         task_queue="google-adk-agents-basic",
     )
     print(f"Result: {result}")
+    # @@@SNIPEND
 
 
 if __name__ == "__main__":

--- a/google_adk_agents/basic/run_worker.py
+++ b/google_adk_agents/basic/run_worker.py
@@ -12,8 +12,7 @@ from google_adk_agents.basic.workflows.hello_world_workflow import (
 
 
 async def main():
-    # Build the plugin once and give the same instance to the client and the
-    # worker.
+    # @@@SNIPSTART google-adk-agents-basic-worker
     plugin = GoogleAdkPlugin()
 
     client = await Client.connect("localhost:7233", plugins=[plugin])
@@ -25,6 +24,7 @@ async def main():
         plugins=[plugin],
     )
     await worker.run()
+    # @@@SNIPEND
 
 
 if __name__ == "__main__":

--- a/google_adk_agents/basic/workflows/hello_world_workflow.py
+++ b/google_adk_agents/basic/workflows/hello_world_workflow.py
@@ -11,23 +11,20 @@ from temporalio.contrib.google_adk_agents import TemporalModel
 class HelloWorldAgentWorkflow:
     @workflow.run
     async def run(self, prompt: str) -> str:
-        # A normal ADK agent. The one Temporal-specific piece is TemporalModel,
-        # which runs each model call as an `invoke_model` activity.
+        # TemporalModel runs each model call as an `invoke_model` activity.
         agent = Agent(
             name="hello_world_agent",
             model=TemporalModel("gemini-2.5-flash"),
             instruction="You only respond in haikus.",
         )
 
-        # InMemoryRunner drives the agent. The plugin points ADK's session-id
-        # generation at workflow.uuid4(), so creating a session here is
-        # replay-safe.
+        # The plugin points ADK's session-id generation at workflow.uuid4(), so
+        # creating a session here is replay-safe.
         runner = InMemoryRunner(agent=agent, app_name="hello_world_app")
         session = await runner.session_service.create_session(
             app_name="hello_world_app", user_id="user"
         )
 
-        # Keep the last bit of text the agent produces.
         final_text = ""
         async with Aclosing(
             runner.run_async(

--- a/google_adk_agents/mcp/run_worker.py
+++ b/google_adk_agents/mcp/run_worker.py
@@ -14,9 +14,7 @@ from google_adk_agents.mcp.workflows.echo_workflow import EchoMcpWorkflow
 
 
 async def main():
-    # The provider adds the echo-list-tools and echo-call-tool activities. Same
-    # as the other samples: build the plugin once and give the same instance to
-    # the client and the worker.
+    # @@@SNIPSTART google-adk-agents-mcp-worker
     plugin = GoogleAdkPlugin(
         toolset_providers=[TemporalMcpToolSetProvider("echo", echo_toolset)]
     )
@@ -30,6 +28,7 @@ async def main():
         plugins=[plugin],
     )
     await worker.run()
+    # @@@SNIPEND
 
 
 if __name__ == "__main__":

--- a/google_adk_agents/mcp/workflows/echo_workflow.py
+++ b/google_adk_agents/mcp/workflows/echo_workflow.py
@@ -15,10 +15,7 @@ class EchoMcpWorkflow:
     @workflow.run
     async def run(self, prompt: str) -> str:
         # TemporalMcpToolSet runs the MCP server's list-tools and call-tool
-        # calls as activities (the provider names them echo-list-tools and
-        # echo-call-tool on the worker). The not_in_workflow_toolset factory
-        # lets you run this same agent locally, outside a workflow, by hitting
-        # the MCP server directly.
+        # calls as activities.
         agent = Agent(
             name="echo_agent",
             model=TemporalModel("gemini-2.5-flash"),

--- a/google_adk_agents/streaming/run_streaming_workflow.py
+++ b/google_adk_agents/streaming/run_streaming_workflow.py
@@ -16,8 +16,6 @@ WORKFLOW_ID = "google-adk-agents-streaming-workflow-id"
 async def main():
     client = await Client.connect("localhost:7233", plugins=[GoogleAdkPlugin()])
 
-    # Start the workflow but don't wait on the result yet, so we can subscribe
-    # to its stream while it's running.
     handle = await client.start_workflow(
         StreamingAgentWorkflow.run,
         "Tell me a short story about a robot learning to paint.",
@@ -25,7 +23,6 @@ async def main():
         task_queue="google-adk-agents-streaming",
     )
 
-    # Subscribe to the "responses" topic and print text chunks as they arrive.
     stream = WorkflowStreamClient.create(client, WORKFLOW_ID)
 
     async def print_chunks() -> None:

--- a/google_adk_agents/streaming/run_worker.py
+++ b/google_adk_agents/streaming/run_worker.py
@@ -12,8 +12,6 @@ from google_adk_agents.streaming.workflows.streaming_workflow import (
 
 
 async def main():
-    # Build the plugin once and give the same instance to the client and the
-    # worker.
     plugin = GoogleAdkPlugin()
 
     client = await Client.connect("localhost:7233", plugins=[plugin])

--- a/google_adk_agents/streaming/workflows/streaming_workflow.py
+++ b/google_adk_agents/streaming/workflows/streaming_workflow.py
@@ -12,15 +12,14 @@ from temporalio.contrib.workflow_streams import WorkflowStream
 class StreamingAgentWorkflow:
     @workflow.init
     def __init__(self, prompt: str) -> None:
-        # The workflow hosts a WorkflowStream. The streaming activity publishes
-        # raw LlmResponse chunks to it as they come back from the model.
+        # The streaming activity publishes LlmResponse chunks to this stream as
+        # they come back from the model.
         self.stream = WorkflowStream()
 
     @workflow.run
     async def run(self, prompt: str) -> str:
-        # streaming_topic is the topic the chunks get published to.
-        # RunConfig(streaming_mode=SSE) tells ADK to stream, which routes the
-        # call through the invoke_model_streaming activity.
+        # streaming_mode=SSE routes the call through the invoke_model_streaming
+        # activity.
         model = TemporalModel("gemini-2.5-flash", streaming_topic="responses")
         agent = Agent(
             name="streaming_agent",

--- a/google_adk_agents/tools/run_worker.py
+++ b/google_adk_agents/tools/run_worker.py
@@ -11,8 +11,7 @@ from google_adk_agents.tools.workflows.weather_workflow import WeatherAgentWorkf
 
 
 async def main():
-    # Build the plugin once and give the same instance to the client and the
-    # worker.
+    # @@@SNIPSTART google-adk-agents-tools-worker
     plugin = GoogleAdkPlugin()
 
     client = await Client.connect("localhost:7233", plugins=[plugin])
@@ -25,6 +24,7 @@ async def main():
         plugins=[plugin],
     )
     await worker.run()
+    # @@@SNIPEND
 
 
 if __name__ == "__main__":

--- a/google_adk_agents/tools/workflows/weather_workflow.py
+++ b/google_adk_agents/tools/workflows/weather_workflow.py
@@ -16,9 +16,8 @@ from google_adk_agents.tools.activities.weather_activity import get_weather
 class WeatherAgentWorkflow:
     @workflow.run
     async def run(self, prompt: str) -> str:
-        # Wrap the get_weather activity as an ADK tool. When the model calls it,
-        # activity_tool runs it as a real Temporal activity instead of inline,
-        # so it's retryable and shows up in history.
+        # activity_tool runs the tool call as a real Temporal activity, so it's
+        # retryable and shows up in history.
         weather_tool = temporalio.contrib.google_adk_agents.workflow.activity_tool(
             get_weather, start_to_close_timeout=timedelta(seconds=60)
         )


### PR DESCRIPTION
Adds SNIPSTART markers around the Worker/Client setup and Workflow starter so the documentation integration page (temporalio/documentation#4759) can pull them via snipsync, and trims the sample comments to short, why-only notes.