### PR TITLE
Discover sample packages instead of listing them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 .mypy_cache/
 **/client.key
 **/client.pem
+*.egg-info/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,59 +84,12 @@ constraint-dependencies = [
     "yarl!=1.24.0",
 ]
 
-[tool.hatch.metadata]
-allow-direct-references = true
-
-[tool.hatch.build.targets.sdist]
-include = ["./**/*.py"]
-exclude = ["lambda_worker/**"]
-
-[tool.hatch.build.targets.wheel]
-include = ["./**/*.py"]
-exclude = ["lambda_worker/**"]
-packages = [
-    "activity_worker",
-    "bedrock",
-    "cloud_export_to_parquet",
-    "context_propagation",
-    "custom_converter",
-    "custom_decorator",
-    "custom_metric",
-    "dsl",
-    "encryption",
-    "external_storage",
-    "external_storage_redis",
-    "gevent_async",
-    "hello",
-    "langgraph_plugin",
-    "langsmith_tracing",
-    "message_passing",
-    "nexus",
-    "open_telemetry",
-    "patching",
-    "polling",
-    "prometheus",
-    "pydantic_converter",
-    "pydantic_converter_v1",
-    "pyproject.toml",
-    "replay",
-    "schedules",
-    "sentry",
-    "sleep_for_days",
-    "strands_plugin",
-    "tests",
-    "trio_async",
-    "updatable_timer",
-    "worker_specific_task_queues",
-    "worker_versioning",
-]
-
-[tool.hatch.build.targets.wheel.sources]
-"./**/*.py" = "**/*.py"
+[tool.setuptools.packages.find]
+exclude = ["lambda_worker*"]
 
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["setuptools>=77"]
+build-backend = "setuptools.build_meta"
 
 [tool.poe.tasks]
 format = [


### PR DESCRIPTION
## Problem

The wheel target listed every sample directory by hand, and hatchling's `packages` setting takes literal paths — it does not accept patterns — so the list had to be maintained manually. It drifted, silently: an entry naming a directory that does not exist is ignored without a warning.

- `nexus` was added in #174, where the directory was actually `hello_nexus`, so it has never matched anything.
- 14 sample directories added since the uv migration (#170) were never shipped, including `google_adk_agents` and `openai_agents`.
- The sdist shipped no samples at all — 6 entries total.

#170 called this out when it introduced the list: *"contributors will have to explicitly add samples to this list... I haven't yet found a way to automatically add top-level directories matching a pattern as packages."* Poetry's previous config globbed (`{include = "**/*.py", from = "."}`); the hatchling translation could not.

## Change

Switch the build backend to setuptools and let `packages.find` discover the samples, so adding a sample needs no build config change:

```toml
[tool.setuptools.packages.find]
exclude = ["lambda_worker*"]

[build-system]
requires = ["setuptools>=77"]
build-backend = "setuptools.build_meta"
```

Net `-51` lines: the 33-entry list, both hatch build targets, the `sources` mapping, and `[tool.hatch.metadata]` all go away. `setuptools>=77` is the floor for PEP 639 (`license = "MIT"` as a string), verified by building under that constraint.

Namespace discovery (the default) is required: `openai_agents/*` and `message_passing/update_with_start/lazy_initialization` have subdirectories without an `__init__.py`, and `namespaces = false` drops 122 files.

## Verification

- Wheel and sdist each contain exactly the 652 tracked sample `.py` files — a set match against `git ls-files` — with no venv, cache, `lambda_worker`, or `.github` content. The wheel previously had 405; the sdist had none.
- A wheel install and an editable install both import samples the old list omitted (`google_adk_agents`, `openai_agents`); running a sample script by path still resolves its absolute imports.
- `pytest tests/strands_plugin tests/langgraph_plugin tests/google_adk_agents` — 27 passed against the reinstalled editable project.

## Notes

- setuptools writes `temporalio_samples.egg-info/` into the working tree, hence the `.gitignore` addition.
- Editable installs now use setuptools' package-map finder rather than a root `.pth`, so a brand-new sample directory is not importable by path until `uv sync` re-runs. CI is unaffected (it syncs after checkout), and pytest is unaffected (rootdir goes on `sys.path`).
- Alternatives considered: `uv_build` documents no support for multiple top-level modules (its `module-name` list form is discouraged, and would be the same 47-entry enumeration); uv's recommended workspace layout would need 47 member manifests plus nesting every sample a level deeper, which changes 237 documented `uv run <path>` commands and every deep link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)