### PR TITLE
Shut down executors in hello_activity_multiprocess

### DIFF
--- a/hello/hello_activity_multiprocess.py
+++ b/hello/hello_activity_multiprocess.py
@@ -2,7 +2,7 @@ import asyncio
 import multiprocessing
 import os
 import time
-from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from dataclasses import dataclass
 from datetime import timedelta
 
@@ -57,14 +57,18 @@ async def main():
     # needs some kind of manager to share state such as cancellation info and
     # heartbeat info between the host and the activity. Therefore, we must
     # provide a shared_state_manager below. A helper is provided to create it
-    # from a multiprocessing manager.
+    # from a multiprocessing manager. That helper also needs a thread pool
+    # executor to poll the heartbeat queue on; it creates one itself if we do not
+    # pass one, so we pass our own to be able to shut it down.
     #
-    # Both are used as context managers so their processes are shut down when we
-    # are done with them. They are entered outside the worker so that they
-    # outlive it.
+    # All three are used as context managers so they are shut down when we are
+    # done with them. They are entered outside the worker so that they outlive
+    # it, and the manager is entered first so that it is torn down last: it owns
+    # the heartbeat queue that the other two are still using as they stop.
     with (
-        ProcessPoolExecutor(5) as activity_executor,
         multiprocessing.Manager() as manager,
+        ThreadPoolExecutor(1) as queue_poller_executor,
+        ProcessPoolExecutor(5) as activity_executor,
     ):
         # Run a worker for the workflow
         async with Worker(
@@ -74,7 +78,7 @@ async def main():
             activities=[compose_greeting],
             activity_executor=activity_executor,
             shared_state_manager=SharedStateManager.create_from_multiprocessing(
-                manager
+                manager, queue_poller_executor
             ),
         ):
             # While the worker is running, use the client to run the workflow and

--- a/hello/hello_activity_multiprocess.py
+++ b/hello/hello_activity_multiprocess.py
@@ -48,36 +48,45 @@ async def main():
     config.setdefault("target_host", "localhost:7233")
     client = await Client.connect(**config)
 
-    # Run a worker for the workflow
-    async with Worker(
-        client,
-        task_queue="hello-activity-multiprocess-task-queue",
-        workflows=[GreetingWorkflow],
-        activities=[compose_greeting],
-        # Synchronous activities are not allowed unless we provide some kind of
-        # executor. Here we are giving a process pool executor which means the
-        # activity will actually run in a separate process. This same executor
-        # could be passed to multiple workers if desired.
-        activity_executor=ProcessPoolExecutor(5),
-        # Since we are using an executor that is not a thread pool executor,
-        # Temporal needs some kind of manager to share state such as
-        # cancellation info and heartbeat info between the host and the
-        # activity. Therefore, we must provide a shared_state_manager here. A
-        # helper is provided to create it from a multiprocessing manager.
-        shared_state_manager=SharedStateManager.create_from_multiprocessing(
-            multiprocessing.Manager()
-        ),
+    # Synchronous activities are not allowed unless we provide some kind of
+    # executor. Here we are giving a process pool executor which means the
+    # activity will actually run in a separate process. This same executor could
+    # be passed to multiple workers if desired.
+    #
+    # Since we are using an executor that is not a thread pool executor, Temporal
+    # needs some kind of manager to share state such as cancellation info and
+    # heartbeat info between the host and the activity. Therefore, we must
+    # provide a shared_state_manager below. A helper is provided to create it
+    # from a multiprocessing manager.
+    #
+    # Both are used as context managers so their processes are shut down when we
+    # are done with them. They are entered outside the worker so that they
+    # outlive it.
+    with (
+        ProcessPoolExecutor(5) as activity_executor,
+        multiprocessing.Manager() as manager,
     ):
-        # While the worker is running, use the client to run the workflow and
-        # print out its result. Note, in many production setups, the client
-        # would be in a completely separate process from the worker.
-        result = await client.execute_workflow(
-            GreetingWorkflow.run,
-            "World",
-            id="hello-activity-multiprocess-workflow-id",
+        # Run a worker for the workflow
+        async with Worker(
+            client,
             task_queue="hello-activity-multiprocess-task-queue",
-        )
-        print(f"Result on PID {os.getpid()}: {result}")
+            workflows=[GreetingWorkflow],
+            activities=[compose_greeting],
+            activity_executor=activity_executor,
+            shared_state_manager=SharedStateManager.create_from_multiprocessing(
+                manager
+            ),
+        ):
+            # While the worker is running, use the client to run the workflow and
+            # print out its result. Note, in many production setups, the client
+            # would be in a completely separate process from the worker.
+            result = await client.execute_workflow(
+                GreetingWorkflow.run,
+                "World",
+                id="hello-activity-multiprocess-workflow-id",
+                task_queue="hello-activity-multiprocess-task-queue",
+            )
+            print(f"Result on PID {os.getpid()}: {result}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What was changed

`hello_activity_multiprocess.py` constructed a `ProcessPoolExecutor` and a `multiprocessing.Manager()` inline in the `Worker(...)` call and never shut either down, so the sample was demonstrating a resource leak. Both are now entered as context managers outside the worker, so they outlive it and are shut down once it is done with them.

Two details worth calling out:

- **The manager is entered first so it is torn down last.** It owns the heartbeat queue, and `_MultiprocessingSharedStateManager._heartbeat_processor` can still be blocked on `self._heartbeat_queue.get(True, 0.5)` for up to its poll timeout after the worker has exited. Shutting the manager down before the pool leaves that read on a dead connection.
- **The queue poller executor is now created explicitly.** `SharedStateManager.create_from_multiprocessing` builds its own `ThreadPoolExecutor(1)` when one is not passed, and neither the shared state manager nor the worker ever shuts it down, so without this the sample would still be leaving an executor unshut. Passing our own lets it be shut down with the others.

That second point is the one piece here that is arguably `sdk-python`'s lifetime problem rather than the sample's. If you would rather the SDK owned that executor, say so and I will drop it and keep this PR to the pool and the manager.

## Not included

The same inline-executor pattern (`activity_executor=ThreadPoolExecutor(5)`) is in about a dozen other samples, including `hello_activity.py`, `hello_cron.py`, `hello_exception.py` and `hello_mtls.py`. I kept this PR to the file the issue names. Happy to do the rest as a follow-up if you want them.

Issue #50 also names `hello_activity_threaded.py`, which was removed in #173. Separately, the root `README.md` still links that deleted file; happy to send a one-line fix for it.

## Testing

- Ran `uv run hello/hello_activity_multiprocess.py` against `temporal server start-dev` four times. The activity runs in a separate process, the result is correct, and the process exits in about four seconds with no shutdown traceback, confirming the added executor does not hang on shutdown.
- `uv run poe lint` clean.

## Checklist

1. Closes #50
