### PR TITLE
Use with_child_unrestricted in pydantic_converter_v1 sample

### DIFF
--- a/pydantic_converter_v1/worker.py
+++ b/pydantic_converter_v1/worker.py
@@ -49,18 +49,11 @@ class MyWorkflow:
 # workflows, we're going to remove datetime module restrictions. See sdk-python
 # README's discussion of known sandbox issues for more details.
 def new_sandbox_runner() -> SandboxedWorkflowRunner:
-    # TODO(cretz): Use with_child_unrestricted when https://github.com/temporalio/sdk-python/issues/254
-    # is fixed and released
-    invalid_module_member_children = dict(
-        SandboxRestrictions.invalid_module_members_default.children
-    )
-    del invalid_module_member_children["datetime"]
     return SandboxedWorkflowRunner(
         restrictions=dataclasses.replace(
             SandboxRestrictions.default,
-            invalid_module_members=dataclasses.replace(
-                SandboxRestrictions.invalid_module_members_default,
-                children=invalid_module_member_children,
+            invalid_module_members=SandboxRestrictions.invalid_module_members_default.with_child_unrestricted(
+                "datetime"
             ),
         )
     )


### PR DESCRIPTION
## What

`pydantic_converter_v1/worker.py` carried a TODO to switch its sandbox setup to
`with_child_unrestricted` once temporalio/sdk-python#254 was fixed and released.
That fix has shipped, so this replaces the manual "copy the children map and
delete the datetime key" workaround with the intended one-liner.

`with_child_unrestricted("datetime")` is equivalent here, and slightly more
complete: for a single-element path it clears the key from `access`, `use`, and
`children`, whereas the old code only removed it from `children`.

Closes #126

## Testing

`pytest tests/pydantic_converter_v1/` passes (workflow round-trips Pydantic
models with datetime fields); `ruff format --check`, `ruff check`, and
`mypy` are clean.
